### PR TITLE
fix Firefox, Safari link click event

### DIFF
--- a/src/player.html
+++ b/src/player.html
@@ -2600,7 +2600,8 @@
 
         // Find `a.file` or `a.folder` element. `e.target` can be children too instead.
         const getTargetEl = (e) => {
-          const anchors = [...e.path].filter((el) => el.nodeName === 'A');
+          const epath = e.path || (e.composedPath && e.composedPath());
+          const anchors = [...epath].filter((el) => el.nodeName === 'A');
           const $anchors = anchors.map((el) => $(el));
           const $fileOrFolder = $anchors.filter(($el) => ($el.hasClass('file') || $el.hasClass('folder')));
 


### PR DESCRIPTION
Uncaught TypeError: e.path is undefined
getTargetEl http://xxx/player.html:2603
clickLink http://xxx/player.html:2610

"The path property of Event objects is non-standard. The standard equivalent is composedPath, which is a method. But it's new.
So you may want to try falling back to that"
https://stackoverflow.com/questions/39245488/event-path-is-undefined-running-in-firefox