### PR TITLE
Fix meta type

### DIFF
--- a/src/player.html
+++ b/src/player.html
@@ -1610,8 +1610,8 @@
 
       function setType(type){
         const metadata = {
-          prop: type,
-          content: 'og:type'
+          prop: 'og:type',
+          content: type
         };
 
         append(createMeta(metadata));


### PR DESCRIPTION
## Summary
- fix setType function to use `og:type` as property
- set meta content value from caller

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840c1a2b3fc83258cc61de194ac9bbb