### PR TITLE
Fix metadata description property

### DIFF
--- a/src/player.html
+++ b/src/player.html
@@ -1601,7 +1601,7 @@
 
       function setDescription(desc) {
         const metas = [
-          'og:desctription',
+          'og:description',
           'twitter:description'
         ];
 


### PR DESCRIPTION
## Summary
- correct `'og:desctription'` typo in `setDescription` function

## Testing
- `grep -n "og:description" -n src/player.html`


------
https://chatgpt.com/codex/tasks/task_e_6840c17174ec8325a8671aff2038e261